### PR TITLE
fix(dependabot): remove deprecated reviewers and add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 
 # Unless a later match takes precedence, @arqetype/engineering will be requested for review when someone opens a pull request
 
-- @arqetype/engineering
+* @arqetype/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Global code ownership
+
+# This file defines code ownership for the entire repository
+
+# Learn more about CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+
+# Unless a later match takes precedence, @arqetype/engineering will be requested for review when someone opens a pull request
+
+- @arqetype/engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     target-branch: 'dev'
-    reviewers:
-      - 'arqetype/engineering'
     schedule:
       interval: daily
       timezone: 'Europe/Paris'


### PR DESCRIPTION
Eliminate the deprecated reviewers field from Dependabot configuration and introduce a CODEOWNERS file to establish global code ownership for the repository.