### PR TITLE
feat: api add filtering sorting pagination to get applications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Root (runs across all apps/packages via Turborepo)
+pnpm dev           # Start Docker infra + all services
+pnpm build         # Build everything in dependency order
+pnpm lint          # Lint all packages
+pnpm test          # Run all tests
+pnpm check-types   # TypeScript strict check across all packages
+pnpm format        # Prettier format all files
+
+# Docker
+pnpm docker:dev    # Start PostgreSQL + Maildev containers only
+pnpm docker:down   # Stop containers
+
+# Single app/package
+pnpm dev --filter=api
+pnpm dev --filter=web
+pnpm test --filter=api
+pnpm test --filter=web
+
+# API tests (from apps/api)
+pnpm test                      # unit tests (jest --passWithNoTests)
+pnpm test:e2e                  # end-to-end (jest --config ./test/jest-e2e.json)
+pnpm test:coverage
+```
+
+## Architecture
+
+**Weaver** is a job application tracker. Monorepo managed by Turborepo + pnpm workspaces.
+
+### Apps
+
+- **`apps/api`** — NestJS 11 REST API on port 4000. PostgreSQL via TypeORM (`synchronize: true` in non-production). JWT auth stored in `auth-token` cookie.
+- **`apps/web`** — Next.js 15 (App Router, Turbopack) frontend on port 3000.
+
+### Packages
+
+- **`packages/db`** — Shared TypeORM entities, DTOs (class-validator), query interfaces, and enum types. Imported by both apps as `@repo/db`. Exports via wildcard: `@repo/db/entities/user`, `@repo/db/dto/auth/sign-up`, `@repo/db/query/application`, etc.
+- **`packages/email`** — React Email templates + Nodemailer utilities. Maildev on port 1080 (dev), React Email preview on 3011.
+- **`packages/ui`** — Shared React component library built on Radix UI + Tailwind CSS.
+
+### API module structure
+
+Every feature is a NestJS module under `apps/api/src/`. Current modules: `auth`, `user`, `health`, `mailer`, `application`.
+
+**Global setup (`app.module.ts`):**
+- `JwtAuthGuard` is registered as a global `APP_GUARD` — all routes are protected by default.
+- Use `@Public()` decorator to opt out of JWT protection.
+- TypeORM entities must be registered in the `entities` array in `app.module.ts` to be active.
+
+**Common decorators (`apps/api/src/common/decorators/`):**
+- `@Public()` — marks a route as unauthenticated
+- `@CurrentUser()` — injects the authenticated `User` entity from the JWT payload
+- `@Roles()` — role-based access (used alongside role guards)
+
+**Auth:** Passport strategies for Local, JWT, GitHub OAuth2, Google OAuth2. OTP (2FA) and email verification are first-class features.
+
+### `packages/db` conventions
+
+- **Entities**: TypeORM entities with `@PrimaryGeneratedColumn('uuid')`, `@CreateDateColumn`, `@UpdateDateColumn`. Soft delete uses `@DeleteDateColumn`.
+- **DTOs**: Use `class-validator` decorators. Paired request/response classes in the same file (e.g., `SignUpDto` + `SignUpResponseDto`).
+- **Queries**: Shared query/filter interfaces live in `src/query/` (e.g., `ApplicationsQuery`, `PaginatedApplications`).
+- **Types**: Enums and plain types in `src/types/<domain>/`.
+
+### Admin vs. user data access pattern
+
+Controllers check `user.role === UserRole.ADMIN` and call the appropriate service method — admin methods have no ownership filter, user methods scope by `userId`. Example:
+
+```ts
+if (user.role === UserRole.ADMIN) return this.service.findById(id);
+return this.service.findByIdAndUser(id, user.id);
+```
+
+Service methods throw `NotFoundException` (not `ForbiddenException`) when a record isn't found or doesn't belong to the user — this avoids leaking resource existence.
+
+## Environment variables
+
+Defined in `.env` at the repo root. Key variables:
+
+```
+NEST_PORT, NEST_DATABASE_HOST/PORT/USER/PASS/NAME
+NEST_EMAIL_HOST/PORT/USER/PASS
+NEST_JWT_SECRET, NEST_JWT_EXPIRATION_TIME
+NEST_FRONT_URL
+NEXT_PUBLIC_POSTHOG_KEY, NEXT_PUBLIC_POSTHOG_HOST
+```

--- a/apps/api/src/application/application.controller.ts
+++ b/apps/api/src/application/application.controller.ts
@@ -8,25 +8,27 @@ import {
   Param,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { ApplicationService } from './application.service';
+import { type ApplicationsQuery } from '@repo/db/query/application';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { User } from '@repo/db/entities/user';
 import { UserRole } from '@repo/db/types/user/roles';
 import { Application } from '@repo/db/entities/application';
 import { ApplicationStatus } from '@repo/db/types/application/status';
 
-@Controller('application')
+@Controller('applications')
 export class ApplicationController {
   constructor(private readonly applicationService: ApplicationService) {}
 
   @HttpCode(HttpStatus.OK)
   @Get()
-  getAll(@CurrentUser() user: User) {
+  getAll(@CurrentUser() user: User, @Query() query: ApplicationsQuery) {
     if (user.role === UserRole.ADMIN) {
-      return this.applicationService.findAll();
+      return this.applicationService.findMany(query);
     }
-    return this.applicationService.findByUser(user.id);
+    return this.applicationService.findMany(query, user.id);
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/api/src/application/application.service.ts
+++ b/apps/api/src/application/application.service.ts
@@ -3,6 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Application } from '@repo/db/entities/application';
 import { ApplicationStatus } from '@repo/db/types/application/status';
+import {
+  ApplicationsQuery,
+  PaginatedApplications,
+} from '@repo/db/query/application';
 import { User } from '@repo/db/entities/user';
 
 @Injectable()
@@ -12,22 +16,47 @@ export class ApplicationService {
     private readonly applicationsRepository: Repository<Application>,
   ) {}
 
-  async findAll(): Promise<Application[]> {
-    try {
-      return await this.applicationsRepository.find();
-    } catch {
-      return null;
-    }
-  }
+  async findMany(
+    query: ApplicationsQuery,
+    userId?: string,
+  ): Promise<PaginatedApplications> {
+    const {
+      status,
+      search,
+      sortBy = 'created_at',
+      sortOrder = 'desc',
+      page = 1,
+      limit = 20,
+    } = query;
 
-  async findByUser(userId: string): Promise<Application[]> {
-    try {
-      return await this.applicationsRepository.find({
-        where: { user: { id: userId } },
-      });
-    } catch {
-      return null;
+    const qb = this.applicationsRepository
+      .createQueryBuilder('application')
+      .leftJoin('application.user', 'user');
+
+    if (userId) qb.where('user.id = :userId', { userId });
+
+    if (status) {
+      const statuses = Array.isArray(status) ? status : [status];
+      qb.andWhere('application.status IN (:...statuses)', { statuses });
     }
+
+    if (search) {
+      qb.andWhere(
+        '(application.company ILIKE :search OR application.position ILIKE :search)',
+        { search: `%${search}%` },
+      );
+    }
+
+    qb.orderBy(
+      `application.${sortBy}`,
+      sortOrder.toUpperCase() as 'ASC' | 'DESC',
+    );
+
+    const offset = (Number(page) - 1) * Number(limit);
+    qb.skip(offset).take(Number(limit));
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total };
   }
 
   async findById(id: string): Promise<Application> {

--- a/packages/db/src/query/application.ts
+++ b/packages/db/src/query/application.ts
@@ -1,0 +1,16 @@
+import { Application } from '../entities/application';
+import { ApplicationStatus } from '../types/application/status';
+
+export interface ApplicationsQuery {
+  status?: ApplicationStatus | ApplicationStatus[];
+  search?: string;
+  sortBy?: keyof Application;
+  sortOrder?: 'asc' | 'desc';
+  page?: number | string;
+  limit?: number | string;
+}
+
+export interface PaginatedApplications {
+  data: Application[];
+  total: number;
+}


### PR DESCRIPTION
This pull request introduces a new query/filtering system for retrieving job applications, refactors the API to support pagination, search, and sorting, and documents repository usage for Claude. The main changes are grouped below:

### Application Query & Pagination Improvements

* Added `ApplicationsQuery` and `PaginatedApplications` interfaces in `packages/db/src/query/application.ts` to standardize query parameters and paginated responses for application listings.
* Refactored `ApplicationService` in `apps/api/src/application/application.service.ts` to replace `findAll` and `findByUser` with a new `findMany` method that supports filtering by status, search, sorting, pagination, and (optionally) user ownership.
* Updated `ApplicationController` in `apps/api/src/application/application.controller.ts` to accept query parameters for application listing and route requests to the new `findMany` method.

### Documentation

* Added `CLAUDE.md` at the repository root to provide guidance for Claude Code, including command references, architecture, conventions, and environment variable descriptions.